### PR TITLE
Netstandard2.0

### DIFF
--- a/KS.Fiks.IO.Crypto/Asic/AsicDecrypter.cs
+++ b/KS.Fiks.IO.Crypto/Asic/AsicDecrypter.cs
@@ -7,7 +7,7 @@ public class AsicDecrypter(IDecryptionService decryptionService) : IAsicDecrypte
 {
     public async Task WriteDecrypted(Task<Stream> encryptedZipStream, string outPath)
     {
-        await using var fileStream = new FileStream(outPath, FileMode.OpenOrCreate);
+        using var fileStream = new FileStream(outPath, FileMode.OpenOrCreate);
         
         try
         {
@@ -37,12 +37,12 @@ public class AsicDecrypter(IDecryptionService decryptionService) : IAsicDecrypte
     {
         var payloads = new List<StreamPayload>();
 
-        await using var stream = await Decrypt(encryptedZipStream).ConfigureAwait(false);
+        using var stream = await Decrypt(encryptedZipStream).ConfigureAwait(false);
         var asiceReader = new AsiceReader().Read(stream);
 
         foreach (var entry in asiceReader.Entries)
         {
-            await using var entryStream = entry.OpenStream();
+            using var entryStream = entry.OpenStream();
             var memoryStream = new MemoryStream();
 
             await entryStream.CopyToAsync(memoryStream).ConfigureAwait(false);

--- a/KS.Fiks.IO.Crypto/KS.Fiks.IO.Crypto.csproj
+++ b/KS.Fiks.IO.Crypto/KS.Fiks.IO.Crypto.csproj
@@ -14,7 +14,7 @@
         <Copyright>Ks-Kommunesektorens Organisasjon</Copyright>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Used by both fiks-io-client-dotnet and fiks-io-send-client-dotnet.
 
 ## Prerequisites
-This library targets .NET Standard 2.1 and .NET 8
+This library targets .NET Standard 2.1, .NET Standard 2.0 and .NET 8.


### PR DESCRIPTION
**Hvorfor er dette gjort?**
Vi er nødt til å støtte netstandard 2.0 i fiks-io klienten dotnet. Noen av konsumentene er på .NET 4.8. Som gjør at vi er nødt til å støtte dette. 

**Hva er gjort:**
La inn støtte for netstandard 2.0. Oppdatert noe kode til å følge netstandard 2.0 (C# 7.3). Readme er også oppdatert.